### PR TITLE
DOC: remove duplicated word in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To add your final project to the website, create a new entry in the file which c
 |FEND|[`_data/fend.yml`](_data/fend.yml)|
 |MWS|[`_data/mws.yml`](_data/mws.yml)|
 
-You can edit this file on github by clicking on 🖋 icon and submitting submitting your changes via PR. 
+You can edit this file on github by clicking on 🖋 icon and submitting your changes via PR. 
 
 #### Entry format
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To add your final project to the website, create a new entry in the file which c
 |FEND|[`_data/fend.yml`](_data/fend.yml)|
 |MWS|[`_data/mws.yml`](_data/mws.yml)|
 
-You can edit this file on github by clicking on 🖋 icon and submitting your changes via PR. 
+You can edit this file on github by clicking on 🖋 icon and submitting your changes via a pull request (PR). 
 
 #### Entry format
 


### PR DESCRIPTION
Removed duplicate word from the 'How to add your project?' paragraph.